### PR TITLE
type: Define core simulation types

### DIFF
--- a/src/game/types.ts
+++ b/src/game/types.ts
@@ -1,0 +1,29 @@
+export interface Vec2 {
+  readonly x: number;
+  readonly y: number;
+}
+
+export interface Entity {
+  readonly id: string;
+  readonly pos: Vec2;
+  readonly vel: Vec2;
+  readonly size: Vec2;
+  readonly alive: boolean;
+}
+
+export interface InputState {
+  readonly left: boolean;
+  readonly right: boolean;
+  readonly up: boolean;
+  readonly down: boolean;
+  readonly fire: boolean;
+}
+
+export interface GameState {
+  readonly tick: number;
+  readonly entities: ReadonlyArray<Entity>;
+  readonly score: number;
+  readonly lives: number;
+  readonly wave: number;
+  readonly phase: "playing" | "gameover";
+}


### PR DESCRIPTION
## Define core simulation types

**Category:** `type` | **Contributor:** HppCEjVLIIE7mrxzLN4eb

Closes #6

### Changes
Create src/game/types.ts exporting: Vec2 (readonly x/y numbers); Entity (id: string, pos: Vec2, vel: Vec2, size: Vec2, alive: boolean); InputState (readonly left/right/up/down/fire booleans); GameState (tick: number, entities: ReadonlyArray<Entity>, score: number, lives: number, wave: number, phase: 'playing'|'gameover'). All fields readonly where feasible to signal pure-functional update flow. Export Readonly<T> helpers only if needed.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*