### PR TITLE
docs: Create src/assets/ subdirectories with README stubs

### DIFF
--- a/src/assets/sounds/README.md
+++ b/src/assets/sounds/README.md
@@ -1,0 +1,8 @@
+# Sounds
+
+This directory reserves gameplay sound assets.
+
+- Purpose: WAV, OGG, and MP3 files for shots, explosions, and invader march steps.
+- Naming: use kebab-case filenames such as `player-shot.wav` and `invader-step-1.ogg`.
+- Preload discipline: per `CONSTITUTION.md`, every sound used in gameplay must load before gameplay starts, with no mid-game asset pops.
+- Future work: a dedicated asset manifest module will enumerate these files for preload orchestration.

--- a/src/assets/sprites/README.md
+++ b/src/assets/sprites/README.md
@@ -1,0 +1,8 @@
+# Sprites
+
+This directory reserves hi-res gameplay sprite assets.
+
+- Purpose: PNG and SVG art for ships, invaders, bullets, explosions, and bunkers.
+- Naming: use kebab-case filenames such as `invader-a.png` and `player-ship.png`.
+- Preload discipline: per `CONSTITUTION.md`, every sprite used in gameplay must load before gameplay starts, with no mid-game asset pops.
+- Future work: a dedicated asset manifest module will enumerate these files for preload orchestration.


### PR DESCRIPTION
## Create src/assets/ subdirectories with README stubs

**Category:** `docs` | **Contributor:** HppCEjVLIIE7mrxzLN4eb

Closes #23

### Changes
Create two README stub files to reserve the asset directories and document the asset-discipline principle from the constitution (all sprites and sounds must load before gameplay starts — no mid-game asset pops). src/assets/sprites/README.md should briefly state: purpose (hi-res sprite PNGs/SVGs for ships, invaders, bullets, explosions, bunkers), naming convention (kebab-case, e.g. invader-a.png, player-ship.png), and that a future asset manifest module will enumerate these for preloading. src/assets/sounds/README.md should similarly state: purpose (WAV/OGG/MP3 for shots, explosions, invader march steps), naming convention, and the same preload discipline. Keep each file under ~25 lines.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*