### PR TITLE
lint: Add ESLint flat config with TypeScript plugin

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,39 @@
+import js from "@eslint/js";
+import tsPlugin from "@typescript-eslint/eslint-plugin";
+import tsParser from "@typescript-eslint/parser";
+
+const sourceFiles = ["src/**/*.{ts,tsx}"];
+const gameFiles = ["src/game/**/*.{ts,tsx}"];
+
+const tsRecommendedConfigs = tsPlugin.configs["flat/recommended"].map((config) => ({
+  ...config,
+  files: sourceFiles,
+}));
+
+export default [
+  {
+    ignores: ["node_modules/**", "dist/**", "coverage/**", "public/**"],
+  },
+  {
+    ...js.configs.recommended,
+    files: sourceFiles,
+  },
+  ...tsRecommendedConfigs,
+  {
+    files: sourceFiles,
+    languageOptions: {
+      parser: tsParser,
+      ecmaVersion: 2022,
+      sourceType: "module",
+    },
+    rules: {
+      "@typescript-eslint/no-explicit-any": "off",
+    },
+  },
+  {
+    files: gameFiles,
+    rules: {
+      "@typescript-eslint/no-explicit-any": "error",
+    },
+  },
+];


### PR DESCRIPTION
## Add ESLint flat config with TypeScript plugin

**Category:** `lint` | **Contributor:** AciXsAOOaMyGu7dAd7q1x

Closes #25

### Changes
Create eslint.config.js (ESLint v9 flat config) at the repo root. Import and apply @eslint/js recommended rules plus typescript-eslint recommended configs. Configure parser for .ts/.tsx files, set ecmaVersion to 2022 and sourceType to module. Target src/**/*.{ts,tsx} and ignore node_modules, dist, coverage, and public. Include rule overrides that ban `any` in game logic paths (src/game/**) per the Constitution's quality standard, while allowing it elsewhere if needed. Export the config array as the default export.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*