### PR TITLE
lint: Add tsconfig.json and tsconfig.node.json for strict TypeScript

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,12 +2,21 @@
   "compilerOptions": {
     "strict": true,
     "target": "ES2022",
-    "lib": ["ES2022", "ESNext"],
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "moduleResolution": "bundler",
-    "noUncheckedIndexedAccess": true,
-    "types": ["node"]
+    "noEmit": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true,
+    "resolveJsonModule": true,
+    "allowImportingTsExtensions": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitOverride": true
   },
-  "files": ["vitest.config.ts"],
-  "include": ["src"]
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
 }

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "emitDeclarationOnly": true
+  },
+  "include": ["vite.config.ts", "vitest.config.ts"]
+}


### PR DESCRIPTION
## Add tsconfig.json and tsconfig.node.json for strict TypeScript

**Category:** `lint` | **Contributor:** HppCEjVLIIE7mrxzLN4eb

Closes #38

### Changes
Create tsconfig.json at the repo root configured for a Vite browser app: target ES2022, lib includes ES2022 and DOM plus DOM.Iterable, module ESNext, moduleResolution bundler, strict: true, noEmit: true, jsx preserved as not needed (omit), esModuleInterop, skipLibCheck, forceConsistentCasingInFileNames, isolatedModules, resolveJsonModule, allowImportingTsExtensions, noUnusedLocals, noUnusedParameters, noFallthroughCasesInSwitch, noImplicitOverride. Include src in the include array. Reference tsconfig.node.json via the references field. Also create tsconfig.node.json for Vite/Vitest config files (e.g. vite.config.ts, vitest.config.ts) with composite: true, target ES2022, module ESNext, moduleResolution bundler, strict: true, skipLibCheck, and include the config file names in its include array. Neither tsconfig should emit JS. Do not create source files — tsc --noEmit with no matching .ts files should still succeed.

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*