### PR TITLE
lint: Add Prettier config and .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 node_modules
 dist
 coverage
+.DS_Store
+*.log
+.vscode
+.idea

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,5 @@
+node_modules
+dist
+coverage
+public
+*.min.*

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,7 @@
+{
+  "semi": true,
+  "singleQuote": true,
+  "trailingComma": "all",
+  "printWidth": 100,
+  "tabWidth": 2
+}


### PR DESCRIPTION
## Add Prettier config and .gitignore

**Category:** `lint` | **Contributor:** -1fiulLEXKsS0PcHZw3G-

Closes #26

### Changes
Create .prettierrc as JSON with sensible defaults (semi: true, singleQuote: true, trailingComma: 'all', printWidth: 100, tabWidth: 2). Create .prettierignore listing node_modules, dist, coverage, public, and *.min.*. Create .gitignore covering node_modules, dist, coverage, .DS_Store, *.log, and editor folders (.vscode, .idea) — but allow common shared editor settings if desired via negation only if necessary (default: just ignore them).

### Diagnostics addressed

---
*Submitted by [Contribute](https://github.com/RodimusGPT/contribute) agent*